### PR TITLE
feat(footer): add footer component with social links and placeholder links

### DIFF
--- a/src/app/footer/footer.component.css
+++ b/src/app/footer/footer.component.css
@@ -1,0 +1,5 @@
+.footer-bottom {
+    text-align: center;
+    margin-bottom: 10px;
+    margin-top: 10px;
+}

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -1,0 +1,23 @@
+<footer class="app-footer">
+  <div class="footer-container">
+    <div class="footer-content">
+      <div class="footer-socials">
+        <h3>Follow Me</h3>
+        <div class="social-icons" *ngFor="let social of footerData.socials">
+          <a [href]="social.link" target="_blank">
+            <span>{{ social.name }}</span>
+            <img [src]="social.icon" alt="TikTok image" />
+          </a>
+        </div>
+      </div>
+
+      <div class="footer-images" *ngFor="let img of footerData.images">
+        <img [src]="img.image" [alt]="img.alt" />
+      </div>
+    </div>
+
+    <div class="footer-bottom">
+      &copy; {{ currentYear }} · Designed by Oscar Viquez, Developed by Shams Hasan · Built with Angular
+    </div>
+  </div>
+</footer>

--- a/src/app/footer/footer.component.spec.ts
+++ b/src/app/footer/footer.component.spec.ts
@@ -1,0 +1,20 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FooterComponent } from './footer.component';
+describe('FooterComponent', () => {
+  let component: FooterComponent;
+  let fixture: ComponentFixture<FooterComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [FooterComponent]
+    });
+    fixture = TestBed.createComponent(FooterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -1,0 +1,33 @@
+import { Component } from '@angular/core';
+const footerMocks = {
+  socials: [{
+    link: '',
+    name: "TikTok",
+    icon: ''
+  }],
+  images: [
+    {
+      image: "",
+      alt: "Wizard101 image 1"
+    },
+    {
+      image: "",
+      alt: "Wizard101 image 2"
+    }
+  ]
+}
+
+
+@Component({
+  selector: 'app-footer',
+  templateUrl: './footer.component.html',
+  styleUrls: ['./footer.component.css']
+
+
+})
+
+
+export class FooterComponent {
+  currentYear = new Date().getFullYear();
+  footerData = footerMocks;
+}


### PR DESCRIPTION
## feat(footer): add footer component with social links and placeholder images

This PR introduces a new `FooterComponent` that includes:

- A section for future social media links (currently mocked)
- Placeholder slots for humorous Wizard101-related images
- A styled bottom bar with a dynamic copyright year
- Mock data structure ready to be replaced with real URLs/assets