### PR TITLE
style(about): add scroll-margin-top for smooth scrolling alignment

### DIFF
--- a/src/app/home/about/about.component.css
+++ b/src/app/home/about/about.component.css
@@ -1,6 +1,11 @@
-.about-container {
-    padding-bottom: 120px;
+#about-section {
+    scroll-margin-top: 75px !important;
 }
+
+.about-container {
+    margin-top: 80px;
+}
+
 .about-section {
     display: flex;
 }
@@ -23,6 +28,7 @@
     gap: 16px;
     color: rgba(72, 72, 72, 1);
 }
+
 .about-description-column {
     margin: 0;
 }


### PR DESCRIPTION
- Set scroll-margin-top: 75px on #about-section to create proper spacing
when scrolling programmatically or via anchor links. Prevents visual
overlap with preceding/following components like Projects and Skills.